### PR TITLE
chore: add CHANGELOG, codecov.yml, and README badges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable changes to dashtam-terminal will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2026-01-18
+
+### Added
+
+- **Initial Release** - Foundation for Dashtam Terminal TUI application
+
+- **Project Structure**
+  - Nested src-layout (`src/dashtam_terminal/`) for installable package
+  - Entry points: `dashtam` (TUI), `dashtam-cli` (CLI companion)
+  - Hexagonal architecture with presentation/domain/infrastructure layers
+
+- **Core Infrastructure**
+  - Textual 7.3+ for TUI framework
+  - Typer 0.21+ for CLI framework
+  - HTTPX with SSE/WebSocket extensions for async API client
+  - Pydantic Settings for configuration
+
+- **Development Infrastructure**
+  - Docker Compose development environment
+  - Docker Compose CI environment
+  - Makefile with development workflow targets
+  - GitHub Actions CI/CD pipeline
+  - MkDocs Material documentation site
+
+- **Code Quality**
+  - Ruff for linting and formatting
+  - Mypy for type checking
+  - pytest with coverage reporting
+  - Markdown linting
+
+### Technical Notes
+
+- **Python**: 3.14+
+- **Key Dependencies**: textual, typer, httpx, httpx-sse, httpx-ws
+- **Package Manager**: UV (not pip)

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,12 @@ help:
 	@echo "  make test            - Run tests"
 	@echo "  make verify          - 🔥 FULL verification (format, lint, type-check, test)"
 	@echo ""
+	@echo "  💡 TEST_PATH - Run specific test file/directory:"
+	@echo "     make test TEST_PATH=tests/unit/test_foo.py"
+	@echo ""
+	@echo "  💡 ARGS - Additional pytest arguments:"
+	@echo "     make test ARGS=\"-k test_foo\""
+	@echo ""
 	@echo "🔧 Utilities:"
 	@echo "  make setup           - First-time setup (idempotent)"
 	@echo "  make check           - Verify Traefik is running"
@@ -150,9 +156,12 @@ type-check: _ensure-dev-running
 	@echo "🔍 Running type checks with mypy..."
 	@docker compose -f compose/docker-compose.dev.yml exec -w /app app uv run mypy src tests
 
+# Default test path (can be overridden with TEST_PATH)
+TEST_PATH_DEFAULT ?= tests/
+
 test: _ensure-dev-running
 	@echo "🧪 Running tests..."
-	@docker compose -f compose/docker-compose.dev.yml exec -T app uv run pytest tests/ -v --cov=src --cov-report=term-missing
+	@docker compose -f compose/docker-compose.dev.yml exec -T app uv run pytest $(if $(TEST_PATH),$(TEST_PATH),$(TEST_PATH_DEFAULT)) -v --cov=src --cov-report=term-missing $(ARGS)
 
 # ==============================================================================
 # COMPREHENSIVE VERIFICATION

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # Dashtam Terminal
 
+> Bloomberg-style TUI for the Dashtam financial data platform
+
+[![Documentation](https://img.shields.io/badge/docs-mkdocs-blue)](https://faiyaz7283.github.io/dashtam-terminal/)
+[![Test Suite](https://github.com/faiyaz7283/dashtam-terminal/workflows/Test%20Suite/badge.svg)](https://github.com/faiyaz7283/dashtam-terminal/actions)
+[![codecov](https://codecov.io/gh/faiyaz7283/dashtam-terminal/branch/development/graph/badge.svg)](https://codecov.io/gh/faiyaz7283/dashtam-terminal)
+[![Python 3.14](https://img.shields.io/badge/python-3.14-blue.svg)](https://www.python.org/downloads/)
+[![Textual](https://img.shields.io/badge/Textual-7.3+-green.svg)](https://textual.textualize.io/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
 A sophisticated terminal user interface (TUI) for the Dashtam financial data platform. Inspired by Bloomberg Terminal, it provides a rich, real-time interface for managing financial accounts, viewing transactions, monitoring holdings, and connecting to financial providers.
 
 ## Features

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,113 @@
+# Codecov Configuration
+# https://docs.codecov.com/docs/codecov-yaml
+
+# Coverage configuration
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"  # Yellow at 70%, green at 100%
+
+  status:
+    # Project-level coverage checks
+    project:
+      default:
+        target: 80%  # Minimum acceptable coverage
+        threshold: 2%  # Allow 2% drop before failing
+        base: auto
+        if_ci_failed: error
+        informational: false
+
+    # Patch-level coverage checks (for new code in PRs)
+    patch:
+      default:
+        target: 85%  # New code should have high coverage
+        threshold: 5%
+        base: auto
+        if_ci_failed: error
+        informational: false
+
+    # Individual file-level changes
+    changes:
+      default:
+        base: auto
+        if_ci_failed: error
+
+# Comment configuration for pull requests
+comment:
+  layout: "header, diff, components, tree"
+  behavior: default  # Update existing comment
+  require_changes: false  # Always comment
+  require_base: false
+  require_head: true
+  branches:
+    - development
+    - main
+
+# Ignore patterns
+ignore:
+  - "tests/**/*"
+  - "docs/**/*"
+  - "**/__init__.py"
+  - "**/conftest.py"
+
+# Component-based coverage
+component_management:
+  default_rules:
+    statuses:
+      - type: project
+        target: 80%
+      - type: patch
+        target: 85%
+
+  individual_components:
+    - component_id: tui
+      name: TUI Layer
+      paths:
+        - src/dashtam_terminal/presentation/tui/**
+
+    - component_id: cli
+      name: CLI Layer
+      paths:
+        - src/dashtam_terminal/presentation/cli/**
+
+    - component_id: domain
+      name: Domain Layer
+      paths:
+        - src/dashtam_terminal/domain/**
+
+    - component_id: infrastructure
+      name: Infrastructure Layer
+      paths:
+        - src/dashtam_terminal/infrastructure/**
+
+    - component_id: core
+      name: Core
+      paths:
+        - src/dashtam_terminal/core/**
+
+# GitHub integration settings
+github_checks:
+  annotations: true
+
+# Codecov CLI settings
+cli:
+  runners:
+    retry_count: 3
+    retry_delay: 2
+
+# Flag management for different test types
+flags:
+  main-tests:
+    paths:
+      - src/
+    carryforward: true
+
+  unit:
+    paths:
+      - src/
+    carryforward: true
+
+  integration:
+    paths:
+      - src/
+    carryforward: true


### PR DESCRIPTION
## Summary

Add missing project configuration files to align with dashtam-api and dashtam-jobs.

## Changes

- **CHANGELOG.md** - Created with v0.1.0 release notes
- **codecov.yml** - Codecov configuration with:
  - Project coverage target: 80%
  - Patch coverage target: 85%
  - Component-based coverage (tui, cli, domain, infrastructure, core)
- **README.md badges** - Added:
  - Documentation (MkDocs)
  - Test Suite
  - Codecov
  - Python 3.14
  - Textual 7.3+
  - MIT License

## Notes

- CI workflow already uploads to Codecov (needs CODECOV_TOKEN secret)
- Matches structure of dashtam-api and dashtam-jobs

Co-Authored-By: Warp <agent@warp.dev>